### PR TITLE
add standalone robotiq gripper nbx & example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ option(ENABLE_PACKAGE_REGISTRY "Add this package to CMake's package registry" Of
 option(ENABLE_ETHERCAT "Build EtherCat interface" Off)
 option(ENABLE_KORTEX "Build Kinova Kortex interface" Off)
 option(ENABLE_KORTEX_API_AUTO_DOWNLOAD "Auto download Kortex API library" Off)
+option(ENABLE_ROBOTIQ "Build standalone Robotiq interfaces" Off)
 option(ENABLE_KELO "Build Kelo interface" Off)
 option(ENABLE_UBX "Build UBX blocks" Off)
 option(ENABLE_DOC "Build documentation" Off)

--- a/include/robif2b/functions/robotiq_gripper.h
+++ b/include/robif2b/functions/robotiq_gripper.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-3.0
+#ifndef ROBIF2B_FUNCTIONS_ROBOTIQ_GRIPPER_H
+#define ROBIF2B_FUNCTIONS_ROBOTIQ_GRIPPER_H
+
+#include "robif2b/types/robotiq_gripper.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void robif2b_robotiq_gripper_configure(struct robif2b_robotiq_gripper_nbx *b);  // Blocking
+void robif2b_robotiq_gripper_shutdown(struct robif2b_robotiq_gripper_nbx *b);
+void robif2b_robotiq_gripper_update(struct robif2b_robotiq_gripper_nbx *b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/robif2b/types/robotiq_gripper.h
+++ b/include/robif2b/types/robotiq_gripper.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0
+#ifndef ROBIF2B_TYPES_ROBOTIQ_GRIPPER_H
+#define ROBIF2B_TYPES_ROBOTIQ_GRIPPER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+
+enum robif2b_robotiq_gripper_obj_status {
+    ROBIF2B_ROBOTIQ_OBJ_MOVING = 0,
+    ROBIF2B_ROBOTIQ_OBJ_DETECTED_OPENING,
+    ROBIF2B_ROBOTIQ_OBJ_DETECTED_CLOSING,
+    ROBIF2B_ROBOTIQ_OBJ_AT_REQUESTED_POSITION,
+    ROBIF2B_ROBOTIQ_OBJ_UNKNOWN
+};
+
+enum robif2b_robotiq_gripper_status {
+    ROBIF2B_ROBOTIQ_RESET = 0,
+    ROBIF2B_ROBOTIQ_IN_PROGRESS,
+    ROBIF2B_ROBOTIQ_COMPLETED,
+    ROBIF2B_ROBOTIQ_UNKNOWN
+};
+
+enum robif2b_robotiq_gripper_error {
+    ROBIF2B_ROBOTIQ_NO_ERROR = 0,
+    ROBIF2B_ROBOTIQ_ERR_MEMORY,
+    ROBIF2B_ROBOTIQ_ERR_CONNECTION,
+    ROBIF2B_ROBOTIQ_ERR_DEACTIVATION,
+    ROBIF2B_ROBOTIQ_ERR_ACTIVATION,
+    ROBIF2B_ROBOTIQ_ERR_READ,
+    ROBIF2B_ROBOTIQ_ERR_WRITE,
+};
+
+struct robif2b_robotiq_gripper_config {
+    const char * port;
+    uint32_t baudrate;
+    double timeout_ms;      // timeout in milliseconds
+    uint8_t slave_address;
+};
+
+struct robif2b_robotiq_gripper_comm;
+
+struct robif2b_robotiq_gripper_nbx {
+    // Configuration
+    struct robif2b_robotiq_gripper_config conf;
+    // Ports
+    uint8_t *position_msr;
+    bool *is_gripper_moving;
+    // Object detection returned from gripper via serial,
+    // doesn't work well for smaller objects
+    enum robif2b_robotiq_gripper_obj_status *obj_detection_status;
+    enum robif2b_robotiq_gripper_status *gripper_status;
+    uint8_t *position_cmd;
+    uint8_t *speed_cmd;
+    uint8_t *force_cmd;
+    enum robif2b_robotiq_gripper_error *error;
+    bool *success;
+    // Internal state
+    struct robif2b_robotiq_gripper_comm *comm;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -4,10 +4,10 @@ target_link_libraries(2dof_example 2dof)
 if(ENABLE_KORTEX)
   add_executable(kinova_gen3_example kinova_gen3_example.c)
   target_link_libraries(kinova_gen3_example kinova_gen3)
-  
+
   add_executable(kinova_gen3_gripper_example kinova_gen3_gripper_example.c)
   target_link_libraries(kinova_gen3_gripper_example kinova_gen3)
- 
+
   add_executable(kinova_gen3_hl_example kinova_gen3_hl_example.c)
   target_link_libraries(kinova_gen3_hl_example kinova_gen3)
 
@@ -40,5 +40,18 @@ if(ENABLE_ETHERCAT)
       )
       install(TARGETS eddie_example DESTINATION bin/${PROJECT_NAME})
     endif()
+  endif()
+endif()
+
+if(ENABLE_ROBOTIQ)
+  add_executable(robotiq_gripper_example robotiq_gripper_example.c)
+  target_link_libraries(robotiq_gripper_example robotiq_gripper )
+
+  if(ENABLE_INSTALL_TARGETS)
+    set_target_properties(robotiq_gripper_example PROPERTIES
+      INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+      INSTALL_RPATH_USE_LINK_PATH TRUE
+    )
+    install(TARGETS robotiq_gripper_example DESTINATION bin/${PROJECT_NAME})
   endif()
 endif()

--- a/src/example/robotiq_gripper_example.c
+++ b/src/example/robotiq_gripper_example.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: LGPL-3.0
+#include <stdio.h>
+#include <unistd.h>
+#include "robif2b/functions/robotiq_gripper.h"
+#include "robif2b/types/robotiq_gripper.h"
+
+#define MICRO_IN_MILI 1000
+
+const char* err_code_to_str(enum robif2b_robotiq_gripper_error error) {
+    switch (error) {
+        case ROBIF2B_ROBOTIQ_NO_ERROR:
+            return "no error";
+        case ROBIF2B_ROBOTIQ_ERR_MEMORY:
+            return "memory";
+        case ROBIF2B_ROBOTIQ_ERR_CONNECTION:
+            return "connection";
+        case ROBIF2B_ROBOTIQ_ERR_ACTIVATION:
+            return "activation";
+        case ROBIF2B_ROBOTIQ_ERR_DEACTIVATION:
+            return "deactivation";
+        case ROBIF2B_ROBOTIQ_ERR_READ:
+            return "read";
+        case ROBIF2B_ROBOTIQ_ERR_WRITE:
+            return "write";
+        default:
+            return "unknown error";
+    }
+}
+
+int main(int argc, char **argv)
+{
+    bool success = false;
+    bool is_gripper_moving = false;
+    uint8_t position_msr = 0;
+    uint8_t position_cmd = 0;
+    uint8_t speed_cmd = 0xFF;
+    uint8_t force_cmd = 0xFF;
+    enum robif2b_robotiq_gripper_obj_status obj_status = ROBIF2B_ROBOTIQ_OBJ_UNKNOWN;
+    enum robif2b_robotiq_gripper_status gripper_status = ROBIF2B_ROBOTIQ_UNKNOWN;
+    enum robif2b_robotiq_gripper_error error = ROBIF2B_ROBOTIQ_NO_ERROR;
+
+    struct robif2b_robotiq_gripper_nbx gripper = {
+        .conf.port = "/dev/ttyUSB0",
+        .conf.baudrate = 115200,
+        .conf.timeout_ms = 1,
+        .conf.slave_address = 0x09,
+        .position_msr = &position_msr,
+        .is_gripper_moving = &is_gripper_moving,
+        .obj_detection_status = &obj_status,
+        .gripper_status = &gripper_status,
+        .position_cmd = &position_cmd,
+        .speed_cmd = &speed_cmd,
+        .force_cmd = &force_cmd,
+        .error = &error,
+        .success = &success,
+    };
+
+    robif2b_robotiq_gripper_configure(&gripper);
+    if (!success) {
+        printf("Configuration failed, error: %s\n", err_code_to_str(error));
+        goto shutdown;
+    }
+
+    printf("Closing the gripper...\n");
+    position_cmd = 0XFF;
+    robif2b_robotiq_gripper_update(&gripper);
+    if (!success) {
+        printf("Closing failed, error: %s\n", err_code_to_str(error));
+        goto shutdown;
+    }
+    while (is_gripper_moving) {
+        robif2b_robotiq_gripper_update(&gripper);
+        printf("Closing, gripper position: %d\n", position_msr);
+        if (!success) {
+            printf("Reading data failed, error: %s\n", err_code_to_str(error));
+            goto shutdown;
+        }
+        usleep(100 * MICRO_IN_MILI);
+    }
+
+    printf("Openning the gripper at slower speed...\n");
+    speed_cmd = 0x0F;
+    position_cmd = 0X00;
+    robif2b_robotiq_gripper_update(&gripper);
+    if (!success) {
+        printf("Opening failed, error: %s\n", err_code_to_str(error));
+        goto shutdown;
+    }
+    while (is_gripper_moving) {
+        robif2b_robotiq_gripper_update(&gripper);
+        printf("Opening, gripper position: %d\n", position_msr);
+        if (!success) {
+            printf("Reading data failed, error: %s\n", err_code_to_str(error));
+            goto shutdown;
+        }
+        usleep(100 * MICRO_IN_MILI);
+    }
+
+shutdown:
+    printf("Shutting down...\n");
+    robif2b_robotiq_gripper_shutdown(&gripper);
+    if (!success) {
+        printf("Shutdown failed, error: %s\n", err_code_to_str(error));
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/nbx/CMakeLists.txt
+++ b/src/nbx/CMakeLists.txt
@@ -11,3 +11,7 @@ endif()
 if(ENABLE_KELO)
   add_subdirectory(kelo)
 endif()
+
+if(ENABLE_ROBOTIQ)
+  add_subdirectory(robotiq)
+endif()

--- a/src/nbx/robotiq/CMakeLists.txt
+++ b/src/nbx/robotiq/CMakeLists.txt
@@ -1,0 +1,26 @@
+find_package(serial)
+find_package(robotiq_driver_noros)
+
+add_library(robotiq_gripper SHARED robotiq_gripper.cpp)
+
+target_include_directories(robotiq_gripper
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(robotiq_gripper
+  PRIVATE
+    robotiq::robotiq_driver_noros
+)
+target_compile_options(robotiq_gripper
+  PRIVATE
+    -Wall -Wextra -pedantic
+)
+
+install(
+  TARGETS robotiq_gripper
+  EXPORT ${PROJECT_NAME}-targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/src/nbx/robotiq/robotiq_gripper.cpp
+++ b/src/nbx/robotiq/robotiq_gripper.cpp
@@ -1,0 +1,164 @@
+#include <cassert>
+#include <chrono>
+#include <memory>
+#include <robotiq_driver_noros/default_driver.hpp>
+#include <robotiq_driver_noros/driver_exception.hpp>
+#include <serial/serial.h>
+#include "robif2b/types/robotiq_gripper.h"
+#include "robif2b/functions/robotiq_gripper.h"
+#include "robotiq_gripper_comm.hpp"
+
+constexpr enum robif2b_robotiq_gripper_obj_status
+to_robif2b_obj_detection_status(rd::DefaultDriver::ObjectDetectionStatus status) {
+    switch (status) {
+        case rd::DefaultDriver::ObjectDetectionStatus::MOVING:
+            return ROBIF2B_ROBOTIQ_OBJ_MOVING;
+        case rd::DefaultDriver::ObjectDetectionStatus::OBJECT_DETECTED_OPENING:
+            return ROBIF2B_ROBOTIQ_OBJ_DETECTED_OPENING;
+        case rd::DefaultDriver::ObjectDetectionStatus::OBJECT_DETECTED_CLOSING:
+            return ROBIF2B_ROBOTIQ_OBJ_DETECTED_CLOSING;
+        case rd::DefaultDriver::ObjectDetectionStatus::AT_REQUESTED_POSITION:
+            return ROBIF2B_ROBOTIQ_OBJ_AT_REQUESTED_POSITION;
+        default:
+            return ROBIF2B_ROBOTIQ_OBJ_UNKNOWN;
+    }
+}
+
+constexpr enum robif2b_robotiq_gripper_status
+to_robif2b_gripper_status(rd::DefaultDriver::GripperStatus status) {
+    switch (status) {
+        case rd::DefaultDriver::GripperStatus::RESET:
+            return ROBIF2B_ROBOTIQ_RESET;
+        case rd::DefaultDriver::GripperStatus::IN_PROGRESS:
+            return ROBIF2B_ROBOTIQ_IN_PROGRESS;
+        case rd::DefaultDriver::GripperStatus::COMPLETED:
+            return ROBIF2B_ROBOTIQ_COMPLETED;
+        default:
+            return ROBIF2B_ROBOTIQ_UNKNOWN;
+    }
+}
+
+void robif2b_robotiq_gripper_publish_measurements(struct robif2b_robotiq_gripper_nbx *b) {
+    assert(b->comm);
+    assert(b->position_msr);
+    assert(b->obj_detection_status);
+    assert(b->gripper_status);
+    assert(b->error);
+    assert(b->success);
+
+    struct robif2b_robotiq_gripper_comm * comm = b->comm;
+
+    try {
+        *b->position_msr = comm->driver->get_gripper_position();
+    } catch (rd::DriverException &) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_READ;
+        *b->success = false;
+        return;
+    }
+    // Reusing flags updated by above get_gripper_position() call
+    *b->obj_detection_status = to_robif2b_obj_detection_status(comm->driver->get_last_obj_detection_status());
+    *b->gripper_status = to_robif2b_gripper_status(comm->driver->get_last_gripper_status());
+    // Copy movement check logic from robotiq_driver
+    *b->is_gripper_moving = *b->obj_detection_status == ROBIF2B_ROBOTIQ_OBJ_MOVING;
+}
+
+void robif2b_robotiq_gripper_configure(struct robif2b_robotiq_gripper_nbx *b) {
+    assert(b);
+    assert(b->error);
+    assert(b->success);
+
+    *b->error = ROBIF2B_ROBOTIQ_NO_ERROR;
+    *b->success = true;
+
+    b->comm = new struct robif2b_robotiq_gripper_comm;
+    if (!b->comm) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_MEMORY;
+        *b->success = false;
+        return;
+    }
+
+    struct robif2b_robotiq_gripper_comm * comm = b->comm;
+
+    try {
+        comm->serial = std::make_unique<rd::DefaultSerial>();
+    } catch (serial::IOException &) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_CONNECTION;
+        *b->success = false;
+        return;
+    }
+
+    comm->serial->set_port(b->conf.port);
+    comm->serial->set_baudrate(b->conf.baudrate);
+    comm->serial->set_timeout(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(b->conf.timeout_ms)));
+
+    comm->driver = std::make_unique<rd::DefaultDriver>(std::move(comm->serial));
+    comm->driver->set_slave_address(b->conf.slave_address);
+
+    bool connected = false;
+    try {
+        connected = comm->driver->connect();
+    } catch (serial::IOException &) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_CONNECTION;
+        *b->success = false;
+        return;
+    }
+    if (!connected) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_CONNECTION;
+        *b->success = false;
+        return;
+    }
+
+    try {
+        comm->driver->deactivate();
+    } catch (rd::DriverException &) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_DEACTIVATION;
+        *b->success = false;
+        return;
+    }
+
+    try {
+        comm->driver->activate();
+    } catch (rd::DriverException &) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_ACTIVATION;
+        *b->success = false;
+        return;
+    }
+
+    robif2b_robotiq_gripper_publish_measurements(b);
+}
+
+void robif2b_robotiq_gripper_shutdown(struct robif2b_robotiq_gripper_nbx *b) {
+    assert(b);
+    assert(b->error);
+    assert(b->success);
+    assert(b->comm);
+
+    delete b->comm;
+
+    *b->error = ROBIF2B_ROBOTIQ_NO_ERROR;
+    *b->success = true;
+}
+
+void robif2b_robotiq_gripper_update(struct robif2b_robotiq_gripper_nbx *b) {
+    assert(b);
+    assert(b->comm);
+    assert(b->error);
+    assert(b->success);
+
+    *b->error = ROBIF2B_ROBOTIQ_NO_ERROR;
+    *b->success = true;
+
+    struct robif2b_robotiq_gripper_comm * comm = b->comm;
+    // Only set_gripper_position() will send data via serial
+    comm->driver->set_force(*b->force_cmd);
+    comm->driver->set_speed(*b->speed_cmd);
+    try {
+        comm->driver->set_gripper_position(*b->position_cmd);
+    } catch (rd::DriverException &) {
+        *b->error = ROBIF2B_ROBOTIQ_ERR_WRITE;
+        *b->success = false;
+        return;
+    }
+
+    robif2b_robotiq_gripper_publish_measurements(b);
+}

--- a/src/nbx/robotiq/robotiq_gripper_comm.hpp
+++ b/src/nbx/robotiq/robotiq_gripper_comm.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0
+#ifndef ROBIF2B_ROBOTIQ_GRIPPER_COMM_HPP
+#define ROBIF2B_ROBOTIQ_GRIPPER_COMM_HPP
+
+#include <robotiq_driver_noros/default_serial.hpp>
+#include <robotiq_driver_noros/default_driver.hpp>
+
+namespace rd = robotiq_driver;
+
+struct robif2b_robotiq_gripper_comm {
+    std::unique_ptr<rd::DefaultSerial> serial;
+    std::unique_ptr<rd::DefaultDriver> driver;
+};
+
+#endif


### PR DESCRIPTION
* Add nbx to directly communicate with Robotiq grippers via serial
* Handle communication with the ROS-independent secorolab/robotiq_driver_noros repo
* Handle exceptions and return error codes in the nbx accordingly.
* Add example that close the gripper and open it slowly, while printing out gripper positions.