### PR TITLE
feat(robotiq-ft): expose force-torque sensor zeroing

### DIFF
--- a/include/robif2b/functions/robotiq_ft_sensor.h
+++ b/include/robif2b/functions/robotiq_ft_sensor.h
@@ -11,6 +11,7 @@ extern "C" {
 void robif2b_robotiq_ft_configure(struct robif2b_robotiq_ft_sensor_nbx *b);  // Blocking
 void robif2b_robotiq_ft_shutdown(struct robif2b_robotiq_ft_sensor_nbx *b);
 void robif2b_robotiq_ft_update(struct robif2b_robotiq_ft_sensor_nbx *b);
+void robif2b_robotiq_ft_zero(struct robif2b_robotiq_ft_sensor_nbx *b);
 
 #ifdef __cplusplus
 }

--- a/src/nbx/robotiq/robotiq_ft_sensor.c
+++ b/src/nbx/robotiq/robotiq_ft_sensor.c
@@ -66,3 +66,11 @@ void robif2b_robotiq_ft_update(struct robif2b_robotiq_ft_sensor_nbx *b) {
 
     *b->success = true;
 }
+
+void robif2b_robotiq_ft_zero(struct robif2b_robotiq_ft_sensor_nbx *b) {
+    assert(b);
+    assert(b->success);
+
+    rq_set_zero();
+    *b->success = true;
+}


### PR DESCRIPTION
- Add the public `robif2b_robotiq_ft_zero()` API.
- Forward zeroing to the Robotiq FT driver.
- Enable generated real-robot communication tests to zero and re-read the FT sensor.